### PR TITLE
Add Doniyor privacy-first search engine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.venv/
+__pycache__/
+*.pyc
+.env

--- a/README.md
+++ b/README.md
@@ -1,1 +1,61 @@
-# search-engine
+# Doniyor — Privacy Focused Search Engine
+
+Doniyor is a custom, privacy-first metasearch engine that proxies your query through our
+backend before retrieving results from DuckDuckGo. The application never stores logs or
+tracking data and exposes both a clean web interface and a JSON API.
+
+## Features
+
+- 🔒 **Privacy-first** – incoming requests are normalized in-memory without persisting logs.
+- 🌐 **Region aware** – choose DuckDuckGo region codes like `us-en`, `uk-en`, etc.
+- 🛡️ **Safe search control** – opt-in or out of adult content filtering.
+- ⚙️ **Developer friendly API** – query results as JSON from `/api/search`.
+- 🎨 **Modern UI** – responsive interface with zero external trackers or fonts.
+
+## Getting Started
+
+Install the dependencies and run the FastAPI server using Uvicorn:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+uvicorn app.main:app --reload
+```
+
+Open http://127.0.0.1:8000 in your browser to use Doniyor.
+
+### Environment Variables
+
+No secrets are required. Doniyor uses DuckDuckGo's public search endpoint and keeps all
+requests anonymous.
+
+### API Usage
+
+```
+GET /api/search?query=privacy%20tools&max_results=5&region=uk-en
+```
+
+Example response:
+
+```json
+{
+  "query": "privacy tools",
+  "count": 5,
+  "results": [
+    {"title": "...", "url": "https://example.com", "snippet": "..."}
+  ]
+}
+```
+
+### Testing
+
+Run the unit test suite with:
+
+```bash
+pytest
+```
+
+## License
+
+MIT

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,72 @@
+"""FastAPI application exposing the Doniyor search engine."""
+
+from __future__ import annotations
+
+from fastapi import FastAPI, HTTPException, Query, Request
+from fastapi.responses import HTMLResponse
+from fastapi.staticfiles import StaticFiles
+from fastapi.templating import Jinja2Templates
+
+from doniyor import DoniyorSearchEngine
+
+app = FastAPI(
+    title="Doniyor",
+    description=(
+        "Doniyor is a privacy-first metasearch experience built on top of DuckDuckGo. "
+        "No personal data is stored or logged."
+    ),
+    version="1.0.0",
+)
+
+templates = Jinja2Templates(directory="app/templates")
+app.mount("/static", StaticFiles(directory="app/static"), name="static")
+
+engine = DoniyorSearchEngine()
+
+
+@app.get("/", response_class=HTMLResponse)
+async def landing_page(request: Request, q: str | None = Query(default=None, alias="q")):
+    error: str | None = None
+    results = []
+    query_text = (q or "").strip()
+
+    if query_text:
+        try:
+            results = engine.search(query_text)
+        except ValueError as exc:
+            error = str(exc)
+        except Exception:
+            error = "We could not retrieve private results at this time. Please try again later."
+
+    context = {
+        "request": request,
+        "query": query_text,
+        "results": results,
+        "error": error,
+        "title": "Doniyor — Private Search",
+    }
+    return templates.TemplateResponse("index.html", context)
+
+
+@app.get("/api/search")
+async def api_search(
+    query: str = Query(..., min_length=1, description="Search phrase"),
+    region: str | None = Query(None, description="Region code such as 'us-en'"),
+    max_results: int | None = Query(None, ge=1, le=50, description="Maximum results to fetch"),
+    safe_search: bool | None = Query(
+        None,
+        description="Enable strict filtering of adult content (defaults to true)",
+    ),
+):
+    try:
+        results = engine.search(query, region=region, max_results=max_results, safe_search=safe_search)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except Exception as exc:  # pragma: no cover - fallback error handling
+        raise HTTPException(status_code=502, detail="Failed to fetch privacy-preserving results") from exc
+
+    return {
+        "query": query,
+        "count": len(results),
+        "results": [result.__dict__ for result in results],
+    }

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -1,0 +1,155 @@
+:root {
+  color-scheme: dark light;
+  --background: #0f172a;
+  --foreground: #f8fafc;
+  --accent: #38bdf8;
+  --muted: #94a3b8;
+  --card-bg: rgba(15, 23, 42, 0.6);
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+body {
+  background: radial-gradient(circle at top, #1e293b, var(--background));
+  color: var(--foreground);
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 2rem 1rem 3rem;
+}
+
+.hero {
+  text-align: center;
+  margin-bottom: 2rem;
+}
+
+.hero h1 {
+  font-size: clamp(2.5rem, 6vw, 4rem);
+  margin: 0 0 0.5rem;
+}
+
+.hero p {
+  margin: 0;
+  color: var(--muted);
+}
+
+main {
+  width: min(800px, 100%);
+  background: var(--card-bg);
+  backdrop-filter: blur(12px);
+  padding: 2rem;
+  border-radius: 1.5rem;
+  box-shadow: 0 20px 70px rgba(15, 23, 42, 0.6);
+}
+
+.search-form {
+  display: flex;
+  gap: 0.75rem;
+  margin-bottom: 2rem;
+}
+
+.search-form input {
+  flex: 1;
+  padding: 0.85rem 1rem;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background-color: rgba(15, 23, 42, 0.6);
+  color: var(--foreground);
+  font-size: 1rem;
+}
+
+.search-form input:focus {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.search-form button {
+  padding: 0.85rem 1.75rem;
+  border-radius: 999px;
+  border: none;
+  background: var(--accent);
+  color: #0f172a;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.search-form button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 15px 30px rgba(56, 189, 248, 0.4);
+}
+
+.alert {
+  background: rgba(239, 68, 68, 0.15);
+  border: 1px solid rgba(239, 68, 68, 0.4);
+  padding: 1rem;
+  border-radius: 1rem;
+  margin-bottom: 1rem;
+  color: #fecaca;
+}
+
+.results ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 1.5rem;
+}
+
+.results li {
+  padding: 1.5rem;
+  border-radius: 1.25rem;
+  background: rgba(15, 23, 42, 0.7);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+}
+
+.results a {
+  color: var(--accent);
+  font-size: 1.15rem;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.results a:hover {
+  text-decoration: underline;
+}
+
+.results .url {
+  margin: 0.35rem 0;
+  color: var(--muted);
+  font-size: 0.95rem;
+  word-break: break-all;
+}
+
+.results .snippet {
+  margin: 0;
+  color: var(--foreground);
+  line-height: 1.6;
+}
+
+.empty-state {
+  text-align: center;
+  color: var(--muted);
+}
+
+footer {
+  margin-top: 2rem;
+  text-align: center;
+  color: var(--muted);
+  max-width: 720px;
+}
+
+@media (max-width: 640px) {
+  main {
+    padding: 1.5rem;
+  }
+
+  .search-form {
+    flex-direction: column;
+  }
+
+  .search-form button {
+    width: 100%;
+  }
+}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{{ title }}</title>
+    <link rel="stylesheet" href="{{ url_for('static', path='styles.css') }}" />
+  </head>
+  <body>
+    <header class="hero">
+      <h1>Doniyor</h1>
+      <p>A private metasearch engine with zero tracking and no ads.</p>
+    </header>
+
+    <main>
+      <form action="/" method="get" class="search-form">
+        <input
+          type="text"
+          name="q"
+          placeholder="Search privately..."
+          value="{{ query }}"
+          autocomplete="off"
+          aria-label="Search query"
+          required
+        />
+        <button type="submit">Search</button>
+      </form>
+
+      {% if error %}
+      <div class="alert">{{ error }}</div>
+      {% endif %}
+
+      {% if results %}
+      <section class="results" aria-live="polite">
+        <h2>Results</h2>
+        <ul>
+          {% for result in results %}
+          <li>
+            <a href="{{ result.url }}" rel="noopener" target="_blank">{{ result.title }}</a>
+            <p class="url">{{ result.url }}</p>
+            <p class="snippet">{{ result.snippet }}</p>
+          </li>
+          {% endfor %}
+        </ul>
+      </section>
+      {% elif query %}
+      <p class="empty-state">No results yet. Try refining your search terms.</p>
+      {% endif %}
+    </main>
+
+    <footer>
+      <p>
+        Doniyor does not track you. Your query is proxied through our service and sent to
+        DuckDuckGo without storing identifying logs.
+      </p>
+    </footer>
+  </body>
+</html>

--- a/doniyor/__init__.py
+++ b/doniyor/__init__.py
@@ -1,0 +1,9 @@
+"""Doniyor search engine package."""
+
+from .search import DoniyorSearchEngine, SearchResult, SearchQuery
+
+__all__ = [
+    "DoniyorSearchEngine",
+    "SearchResult",
+    "SearchQuery",
+]

--- a/doniyor/search.py
+++ b/doniyor/search.py
@@ -1,0 +1,124 @@
+"""Core search utilities for the Doniyor privacy-focused search engine."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Iterator, List, Optional
+import html
+import re
+
+from duckduckgo_search import DDGS
+
+
+_SAFE_SEARCH_MAP = {
+    True: "moderate",
+    False: "off",
+}
+
+
+@dataclass(slots=True)
+class SearchResult:
+    """A single search result item."""
+
+    title: str
+    url: str
+    snippet: str
+
+    @classmethod
+    def from_ddg(cls, item: dict) -> "SearchResult":
+        """Create a :class:`SearchResult` from a duckduckgo-search result."""
+
+        title = html.unescape(item.get("title") or "")
+        href = item.get("href") or ""
+        body = html.unescape(item.get("body") or "")
+        return cls(title=title.strip(), url=href.strip(), snippet=_clean_snippet(body))
+
+
+@dataclass(slots=True)
+class SearchQuery:
+    """Normalized representation of a user search query."""
+
+    text: str
+    region: str
+    max_results: int
+    safe_search: bool
+
+
+def _clean_snippet(snippet: str) -> str:
+    snippet = re.sub(r"\s+", " ", snippet).strip()
+    return snippet
+
+
+class DoniyorSearchEngine:
+    """A privacy-first wrapper around DuckDuckGo search."""
+
+    def __init__(
+        self,
+        *,
+        default_region: str = "us-en",
+        default_max_results: int = 10,
+        safe_search: bool = True,
+    ) -> None:
+        self._default_region = default_region
+        self._default_max_results = max(1, default_max_results)
+        self._default_safe_search = safe_search
+
+    def build_query(
+        self,
+        text: str,
+        *,
+        region: Optional[str] = None,
+        max_results: Optional[int] = None,
+        safe_search: Optional[bool] = None,
+    ) -> SearchQuery:
+        if not text or not text.strip():
+            raise ValueError("Query text must be non-empty")
+
+        normalized = " ".join(text.split())
+        return SearchQuery(
+            text=normalized,
+            region=region or self._default_region,
+            max_results=max(1, max_results or self._default_max_results),
+            safe_search=self._default_safe_search if safe_search is None else safe_search,
+        )
+
+    def search(
+        self,
+        text: str,
+        *,
+        region: Optional[str] = None,
+        max_results: Optional[int] = None,
+        safe_search: Optional[bool] = None,
+    ) -> List[SearchResult]:
+        query = self.build_query(text, region=region, max_results=max_results, safe_search=safe_search)
+        return list(self._execute(query))
+
+    def _execute(self, query: SearchQuery) -> Iterator[SearchResult]:
+        ddg_safe_mode = _SAFE_SEARCH_MAP[bool(query.safe_search)]
+        with DDGS() as ddgs:
+            generator = ddgs.text(
+                query=query.text,
+                region=query.region,
+                safesearch=ddg_safe_mode,
+                max_results=query.max_results,
+            )
+            seen_urls: set[str] = set()
+            for item in generator:
+                if not isinstance(item, dict):
+                    continue
+                result = SearchResult.from_ddg(item)
+                if not result.url or result.url in seen_urls:
+                    continue
+                seen_urls.add(result.url)
+                yield result
+
+    def search_iter(
+        self,
+        text: str,
+        *,
+        region: Optional[str] = None,
+        max_results: Optional[int] = None,
+        safe_search: Optional[bool] = None,
+    ) -> Iterable[SearchResult]:
+        query = self.build_query(text, region=region, max_results=max_results, safe_search=safe_search)
+        return self._execute(query)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+fastapi>=0.110,<0.111
+uvicorn[standard]>=0.29,<0.30
+jinja2>=3.1,<4.0
+duckduckgo-search>=7.0,<9.0
+httpx>=0.27,<0.28
+pydantic>=2.6,<3.0
+pytest>=8.1,<9.0

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from typing import Iterable
+from types import SimpleNamespace
+
+import pytest
+
+from doniyor.search import DoniyorSearchEngine, SearchResult
+
+
+def fake_ddg_results(items: Iterable[dict]):
+    class _FakeDDGS:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def text(self, *_, **__):
+            return iter(items)
+
+    return _FakeDDGS()
+
+
+def test_build_query_normalizes_whitespace():
+    engine = DoniyorSearchEngine()
+    query = engine.build_query("  privacy   search  ")
+    assert query.text == "privacy search"
+
+
+def test_search_filters_duplicates(monkeypatch):
+    results = [
+        {"title": "Result 1", "href": "https://example.com/a", "body": " A summary "},
+        {"title": "Result 2", "href": "https://example.com/a", "body": "Duplicate URL"},
+        {"title": "Result 3", "href": "https://example.com/b", "body": "More info"},
+    ]
+
+    engine = DoniyorSearchEngine()
+
+    monkeypatch.setattr("doniyor.search.DDGS", lambda: fake_ddg_results(results))
+
+    search_results = engine.search("privacy")
+    assert len(search_results) == 2
+    assert all(isinstance(item, SearchResult) for item in search_results)


### PR DESCRIPTION
## Summary
- implement a FastAPI application that serves the Doniyor privacy-focused metasearch UI and JSON API
- add a DuckDuckGo-backed DoniyorSearchEngine with deduplication and safe-search controls
- document setup/testing and add CSS, templates, and pytest coverage for core behavior

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3cabe91d88322b8455f3b91c924ea